### PR TITLE
(PE-33603) make project name match description in yaml

### DIFF
--- a/.github/workflows/snyk_merge.yaml
+++ b/.github/workflows/snyk_merge.yaml
@@ -21,4 +21,4 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_PE_TOKEN }}
         with:
           command: monitor
-          args: --file=package-lock.json --org=puppet-enterprise --project-name=i18n-gettext-converter
+          args: --file=package-lock.json --org=puppet-enterprise --project-name=i18next-gettext-converter


### PR DESCRIPTION
This updates the name of the project in the yaml file to match the name of the repo in github.